### PR TITLE
Do not install example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ clean: ## Clean the source tree
 format: ## Reformat all code
 	dune build @fmt --auto-promote
 
-.PHONY: run
-run: build etc/GeoLite2-City.mmdb
-	_build/default/src/example/example.exe
+.PHONY: example
+example: etc/GeoLite2-City.mmdb ## Build and run the example
+	dune exec src/example/example.exe
 
 etc/GeoLite2-City.mmdb:
 	mkdir -p etc

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ OCaml bindings to the MaxMind Geo IP database (also known as GeoIP2).
 1. Run a super messy example:
 
    ```sh
-   make run
+   make example
    ```

--- a/src/example/dune
+++ b/src/example/dune
@@ -1,4 +1,3 @@
 (executable
  (name example)
- (public_name example)
  (libraries base stdio mmdb_ffi mmdb_types))


### PR DESCRIPTION
example.exe pulls in stdio which might be avoided, possibly. In any case, no sense in installing it when installing this package.