### PR TITLE
Fail the build if the formatting is wrong

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - TESTS=true
   matrix:
     - OCAML_VERSION=4.04
-    - OCAML_VERSION=4.07
+    - OCAML_VERSION=4.07 EXTRA_DEPS="ocamlformat.0.9" PRE_INSTALL_HOOK="make format"
 addons:
   apt:
     update: true


### PR DESCRIPTION
This prevents merging code that compiles but formatting would yield changes. Assures that builds only succeed if the format target didn't need to reformat things.

We talked about this before and decided it is a good idea, so here's what I did in orewa to assure formatting is consistent.